### PR TITLE
Add network sync for mob scale

### DIFF
--- a/src/main/java/com/dragonslayer/dragonsbuildtools/BuildTools.java
+++ b/src/main/java/com/dragonslayer/dragonsbuildtools/BuildTools.java
@@ -49,6 +49,7 @@ public class BuildTools
 
     private void commonSetup(final FMLCommonSetupEvent event)
     {
+        net.neoforged.neoforge.network.registration.NetworkRegistry.setup();
     }
 
     // Add the example block item to the building blocks tab

--- a/src/main/java/com/dragonslayer/dragonsbuildtools/event/RandomMobInheritEvents.java
+++ b/src/main/java/com/dragonslayer/dragonsbuildtools/event/RandomMobInheritEvents.java
@@ -7,6 +7,7 @@ import com.dragonslayer.dragonsbuildtools.goals.GenericLeaveBlockGoal;
 import com.dragonslayer.dragonsbuildtools.goals.GenericShulkerBulletGoal;
 import com.dragonslayer.dragonsbuildtools.goals.GenericTakeBlockGoal;
 import com.dragonslayer.dragonsbuildtools.goals.GenericBowAttackGoal;
+import com.dragonslayer.dragonsbuildtools.network.NetworkHandler;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
@@ -147,6 +148,9 @@ public class RandomMobInheritEvents {
             } else {
                 System.out.println("❌ mob is NOT ScaleAccessor");
             }
+            if (!event.getLevel().isClientSide()) {
+                NetworkHandler.sendScaleUpdate(mob, scale);
+            }
             return;
         }
         if (realMob.getPersistentData().getBoolean("dragonsbuildtools_slime_skip_split")) {
@@ -159,6 +163,9 @@ public class RandomMobInheritEvents {
             }
             realMob.getPersistentData().putBoolean("dragonsbuildtools_slime_skip_split", false);
             realMob.getPersistentData().putBoolean("dragonsbuildtools_slime_split", false);
+            if (!event.getLevel().isClientSide()) {
+                NetworkHandler.sendScaleUpdate(mob, scale);
+            }
             return;
         }
         if (event.getLevel().isClientSide()) return;
@@ -166,6 +173,7 @@ public class RandomMobInheritEvents {
             float scale = realMob.getPersistentData().getFloat("dragonsbuildtools_scale");
             ((ScaleAccessor) realMob).dragonsbuildtools$setScale(scale);
             realMob.refreshDimensions();
+            NetworkHandler.sendScaleUpdate(realMob, scale);
             return;
         }
         if (realMob.getPersistentData().getBoolean("dragonsbuildtools_slime_skip_split")) {
@@ -174,6 +182,7 @@ public class RandomMobInheritEvents {
             realMob.getPersistentData().putBoolean("dragonsbuildtools_slime_skip_split", false);
             realMob.getPersistentData().putBoolean("dragonsbuildtools_slime_split", false);
             realMob.refreshDimensions();
+            NetworkHandler.sendScaleUpdate(realMob, scale);
             return;
         }
         try {
@@ -196,6 +205,7 @@ public class RandomMobInheritEvents {
         mob.getPersistentData().putBoolean("dragonsbuildtools_climbWallsLikeSpider", false);
         mob.getPersistentData().putBoolean("dragonsbuildtools_slime_split", false);
         mob.getPersistentData().putFloat("dragonsbuildtools_scale", 1f);
+        NetworkHandler.sendScaleUpdate(mob, 1f);
         mob.refreshDimensions();
         // Randomly pick a source type from the ability map
         EntityType<?>[] sourceTypes = ABILITY_MAP.keySet().toArray(new EntityType[0]); //May have hostile abilites while a passive ai
@@ -215,6 +225,7 @@ public class RandomMobInheritEvents {
             }
             if (abilities.contains("dragonsbuildtools_slime_split")) {
                 mob.getPersistentData().putFloat("dragonsbuildtools_scale", 1.0F);
+                NetworkHandler.sendScaleUpdate(mob, 1.0F);
             }
         }
     }
@@ -264,6 +275,7 @@ public class RandomMobInheritEvents {
             } else {
                 System.out.println("❌ mob is NOT ScaleAccessor");
             }
+            NetworkHandler.sendScaleUpdate(child, child.getPersistentData().getFloat("dragonsbuildtools_scale"));
             child.refreshDimensions();
             level.addFreshEntity(child);
         }

--- a/src/main/java/com/dragonslayer/dragonsbuildtools/network/NetworkHandler.java
+++ b/src/main/java/com/dragonslayer/dragonsbuildtools/network/NetworkHandler.java
@@ -1,0 +1,33 @@
+package com.dragonslayer.dragonsbuildtools.network;
+
+import com.dragonslayer.dragonsbuildtools.BuildTools;
+import net.minecraft.world.entity.Entity;
+import net.neoforged.bus.api.SubscribeEvent;
+import net.neoforged.fml.common.EventBusSubscriber;
+import net.neoforged.neoforge.network.PacketDistributor;
+import net.neoforged.neoforge.network.event.RegisterPayloadHandlersEvent;
+import net.neoforged.neoforge.network.handling.IPayloadContext;
+import net.neoforged.neoforge.network.registration.PayloadRegistrar;
+
+@EventBusSubscriber(modid = BuildTools.MOD_ID, bus = EventBusSubscriber.Bus.MOD)
+public class NetworkHandler {
+
+    @SubscribeEvent
+    public static void registerPayloads(RegisterPayloadHandlersEvent event) {
+        PayloadRegistrar registrar = event.registrar("1");
+        registrar.playToClient(ScaleUpdatePayload.TYPE, ScaleUpdatePayload.STREAM_CODEC, NetworkHandler::handleScaleUpdate);
+    }
+
+    private static void handleScaleUpdate(ScaleUpdatePayload payload, IPayloadContext context) {
+        context.enqueueWork(() -> {
+            Entity entity = context.player().level().getEntity(payload.entityId());
+            if (entity != null) {
+                entity.getPersistentData().putFloat("dragonsbuildtools_scale", payload.scale());
+            }
+        });
+    }
+
+    public static void sendScaleUpdate(Entity entity, float scale) {
+        PacketDistributor.sendToPlayersTrackingEntityAndSelf(entity, new ScaleUpdatePayload(entity.getId(), scale));
+    }
+}

--- a/src/main/java/com/dragonslayer/dragonsbuildtools/network/ScaleUpdatePayload.java
+++ b/src/main/java/com/dragonslayer/dragonsbuildtools/network/ScaleUpdatePayload.java
@@ -1,0 +1,22 @@
+package com.dragonslayer.dragonsbuildtools.network;
+
+import com.dragonslayer.dragonsbuildtools.BuildTools;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+
+public record ScaleUpdatePayload(int entityId, float scale) implements CustomPacketPayload {
+    public static final Type<ScaleUpdatePayload> TYPE = new Type<>(ResourceLocation.fromNamespaceAndPath(BuildTools.MOD_ID, "scale_update"));
+    public static final StreamCodec<FriendlyByteBuf, ScaleUpdatePayload> STREAM_CODEC = StreamCodec.composite(
+            ByteBufCodecs.VAR_INT, ScaleUpdatePayload::entityId,
+            ByteBufCodecs.FLOAT, ScaleUpdatePayload::scale,
+            ScaleUpdatePayload::new
+    );
+
+    @Override
+    public Type<ScaleUpdatePayload> type() {
+        return TYPE;
+    }
+}


### PR DESCRIPTION
## Summary
- register a new ScaleUpdatePayload packet
- send scale updates in RandomMobInheritEvents
- handle packet on the client in NetworkHandler
- initialize network registry in BuildTools

## Testing
- `./gradlew build -x test`

------
https://chatgpt.com/codex/tasks/task_e_68523582b68883328502a2d508d22821