### PR TITLE
Implement mob scale sync packet

### DIFF
--- a/src/main/java/com/dragonslayer/dragonsbuildtools/event/RandomMobInheritEvents.java
+++ b/src/main/java/com/dragonslayer/dragonsbuildtools/event/RandomMobInheritEvents.java
@@ -38,6 +38,7 @@ import net.neoforged.bus.api.SubscribeEvent;
 import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.EventHooks;
 import net.neoforged.neoforge.event.entity.EntityJoinLevelEvent;
+import com.dragonslayer.dragonsbuildtools.network.BuildToolsNetwork;
 import net.neoforged.neoforge.event.entity.living.LivingDeathEvent;
 
 import java.lang.reflect.Field;
@@ -144,6 +145,7 @@ public class RandomMobInheritEvents {
             if (mob instanceof ScaleAccessor) {
                 System.out.println("✅ mob is ScaleAccessor");
                 ((ScaleAccessor) mob).dragonsbuildtools$setScale(scale);
+                BuildToolsNetwork.sendScaleSync(mob, scale);
             } else {
                 System.out.println("❌ mob is NOT ScaleAccessor");
             }
@@ -154,6 +156,7 @@ public class RandomMobInheritEvents {
             if (mob instanceof ScaleAccessor) {
                 System.out.println("✅ mob is ScaleAccessor");
                 ((ScaleAccessor) mob).dragonsbuildtools$setScale(scale);
+                BuildToolsNetwork.sendScaleSync(mob, scale);
             } else {
                 System.out.println("❌ mob is NOT ScaleAccessor");
             }
@@ -165,12 +168,14 @@ public class RandomMobInheritEvents {
         if(mob.getPersistentData().getBoolean("dragonsbuildtools_slime_split") && !realMob.getPersistentData().getBoolean("dragonsbuildtools_slime_skip_split")) {
             float scale = realMob.getPersistentData().getFloat("dragonsbuildtools_scale");
             ((ScaleAccessor) realMob).dragonsbuildtools$setScale(scale);
+            BuildToolsNetwork.sendScaleSync(realMob, scale);
             realMob.refreshDimensions();
             return;
         }
         if (realMob.getPersistentData().getBoolean("dragonsbuildtools_slime_skip_split")) {
             float scale = realMob.getPersistentData().getFloat("dragonsbuildtools_scale");
             ((ScaleAccessor) realMob).dragonsbuildtools$setScale(scale);
+            BuildToolsNetwork.sendScaleSync(realMob, scale);
             realMob.getPersistentData().putBoolean("dragonsbuildtools_slime_skip_split", false);
             realMob.getPersistentData().putBoolean("dragonsbuildtools_slime_split", false);
             realMob.refreshDimensions();
@@ -197,6 +202,7 @@ public class RandomMobInheritEvents {
         mob.getPersistentData().putBoolean("dragonsbuildtools_slime_split", false);
         mob.getPersistentData().putFloat("dragonsbuildtools_scale", 1f);
         mob.refreshDimensions();
+        BuildToolsNetwork.sendScaleSync(mob, mob.getPersistentData().getFloat("dragonsbuildtools_scale"));
         // Randomly pick a source type from the ability map
         EntityType<?>[] sourceTypes = ABILITY_MAP.keySet().toArray(new EntityType[0]); //May have hostile abilites while a passive ai
         EntityType<?> sourceType = sourceTypes[mob.getRandom().nextInt(sourceTypes.length)];
@@ -217,6 +223,7 @@ public class RandomMobInheritEvents {
                 mob.getPersistentData().putFloat("dragonsbuildtools_scale", 1.0F);
             }
         }
+        BuildToolsNetwork.sendScaleSync(mob, mob.getPersistentData().getFloat("dragonsbuildtools_scale"));
     }
 
     private static void wipeGoals(Mob mob) throws Exception {
@@ -265,6 +272,7 @@ public class RandomMobInheritEvents {
                 System.out.println("❌ mob is NOT ScaleAccessor");
             }
             child.refreshDimensions();
+            BuildToolsNetwork.sendScaleSync(child, child.getPersistentData().getFloat("dragonsbuildtools_scale"));
             level.addFreshEntity(child);
         }
 

--- a/src/main/java/com/dragonslayer/dragonsbuildtools/network/BuildToolsNetwork.java
+++ b/src/main/java/com/dragonslayer/dragonsbuildtools/network/BuildToolsNetwork.java
@@ -1,0 +1,10 @@
+package com.dragonslayer.dragonsbuildtools.network;
+
+import net.minecraft.world.entity.Mob;
+import net.neoforged.neoforge.network.PacketDistributor;
+
+public class BuildToolsNetwork {
+    public static void sendScaleSync(Mob mob, float scale) {
+        PacketDistributor.sendToPlayersTrackingEntityAndSelf(mob, new ScaleSyncPayload(mob.getId(), scale));
+    }
+}

--- a/src/main/java/com/dragonslayer/dragonsbuildtools/network/ScaleSyncPayload.java
+++ b/src/main/java/com/dragonslayer/dragonsbuildtools/network/ScaleSyncPayload.java
@@ -1,0 +1,23 @@
+package com.dragonslayer.dragonsbuildtools.network;
+
+import com.dragonslayer.dragonsbuildtools.BuildTools;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.codec.ByteBufCodecs;
+import net.minecraft.network.codec.StreamCodec;
+import net.minecraft.network.protocol.common.custom.CustomPacketPayload;
+import net.minecraft.resources.ResourceLocation;
+
+public record ScaleSyncPayload(int entityId, float scale) implements CustomPacketPayload {
+    public static final Type<ScaleSyncPayload> TYPE = new Type<>(ResourceLocation.parse(BuildTools.MOD_ID + ":scale_sync"));
+    public static final StreamCodec<FriendlyByteBuf, ScaleSyncPayload> STREAM_CODEC = StreamCodec.composite(
+            ByteBufCodecs.VAR_INT,
+            ScaleSyncPayload::entityId,
+            ByteBufCodecs.FLOAT,
+            ScaleSyncPayload::scale,
+            ScaleSyncPayload::new);
+
+    @Override
+    public Type<ScaleSyncPayload> type() {
+        return TYPE;
+    }
+}


### PR DESCRIPTION
## Summary
- add network helpers and a `ScaleSyncPayload`
- sync mob scale to clients when mobs spawn or split

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68523582b68883328502a2d508d22821